### PR TITLE
Use user and host value from webfinger when adding users

### DIFF
--- a/inc/user.php
+++ b/inc/user.php
@@ -66,7 +66,7 @@ function addUser($label)
 		return '<p><span class="error">I cannot find the profile page <b><a href="'.substr($err,10).'" target="_blank">'.substr($err,10).'</b></span>';
 
 	
-	if (!$magic = validUser($label, true)) return '<p><span class="error">Your fediverse profile is missing the magic word. Please proceed to step 1 first and then join again.</span>';
+	if (!$magic = validUser($label, $user, $host, true)) return '<p><span class="error">Your fediverse profile is missing the magic word. Please proceed to step 1 first and then join again.</span>';
 	
 	
 	debugLog('<p>Valid user. Going to index.');
@@ -102,16 +102,10 @@ function addUser($label)
 	
 }
 	
-function validUser($label, $refresh = false)
+function validUser($label, $user, $host, $refresh = false)
 {
 	global $tfRoot;
 	debugLog('<p>validUser '.$label);
-	
-	
-	preg_match('/@([a-zA-Z0-9_]+)@([a-zA-Z0-9_-]+\.[a-zA-Z0-9.-]+)/',$label,$matches); // @user@example.com // can have two . in domain!
-	if (count($matches)<3) return false; 
-	$host = $matches[2];
-	$user = $matches[1];
 
 	$localpath = $tfRoot.'/site/profiles/'.$label.'.json';
 	


### PR DESCRIPTION
Before, when attempting to add a new user from a Mastodon instance with difference LOCAL_DOMAIN and WEB_DOMAIN, the addition would fail. The lookup of redirects in the host-meta and webfinger results would occur, but wouldn't be used throughout the process of adding a new user to the indexer.

Now, the determined user and host values are used throughout the process.

---

I'll admit, I don't actually know PHP, but this is currently blocking me from adding my account to Tootfinder, so I figure I'd take a what at fixing the issue. If you need a test account, mine (`@dbendit@eroticmohel.com`) is currently not working (I always get the `Your fediverse profile is missing the magic word. Please proceed to step 1 first and then join again.` error, which seems to be coming up in more cases than you really want). My instance is hosted at `mastodon.eroticmohel.com`, which is leading to this issue. I've verified manually that the host-meta and webfinger redirects are set up properly, and other Mastodon instances are able to federate with mine just fine.